### PR TITLE
Release 7.4.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:7.4.16-apache
 LABEL maintainer="matt_henderson@sil.org"
 
 RUN apt-get update -y && \


### PR DESCRIPTION
### Fixed
- Use a more specific version of PHP, to make updates easier to control
- Change versioning scheme to match PHP version

---

@fillup and @Schparky - What do you think of having the version tags on this repo match the PHP version specified in the Dockerfile? It seems more clear (you know what version of PHP you're getting), and we should be able to automate updates to this repo (to newer versions of PHP) that way.